### PR TITLE
Use location.host for non-default ports in appURL

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -42,7 +42,7 @@ export default createStore({
             if (location.hostname === 'localhost' && location.port === '5176')
                 return `http://localhost${import.meta.env.BASE_URL}${state.app.backendDir}`;
             else
-                return `${location.protocol}//${location.hostname}${import.meta.env.BASE_URL}${state.app.backendDir}`;
+                return `${location.protocol}//${location.port !== '80' ? location.host : location.hostname}${import.meta.env.BASE_URL}${state.app.backendDir}`;
         },
 
         // get window height


### PR DESCRIPTION
When the app runs on a port other than the default HTTP port 80 (which browsers assume for `http://localhost`), `window.location.hostname` omits the port (so it stays `localhost` even if you’re on `:5176` or `:8000`), leading AJAX calls to target the wrong origin and causing connection errors . This PR:

- Checks `location.port` and, if it’s non-zero and not `"80"`, switches to `location.host` (which includes `:port`).  
- Falls back to `location.hostname` when on the default HTTP port.

**Before**  
```js
return `${location.protocol}//${location.hostname}${import.meta.env.BASE_URL}${state.app.backendDir}`;
```

**After**  
```js
return `${location.protocol}//${location.port !== '80' ? location.host : location.hostname}${import.meta.env.BASE_URL}${state.app.backendDir}`;
// ⇒ http://localhost:8080/sportsfest-litmusda/…  ⇒ If there is a port other than 80
// ⇒ http://localhost/sportsfest-litmusda/…  ⇒ If it's a default port (80) 
```

<br>
